### PR TITLE
remove useless codes

### DIFF
--- a/Music Downloader/Music Downloader.csproj
+++ b/Music Downloader/Music Downloader.csproj
@@ -159,8 +159,6 @@
     <EmbeddedResource Include="obj\Debug\Music_Downloader.About.resources" />
     <EmbeddedResource Include="obj\Debug\Music_Downloader.Form1.resources" />
     <EmbeddedResource Include="obj\Debug\Music_Downloader.Properties.Resources.resources" />
-    <EmbeddedResource Include="obj\Debug\Netease_Music_Downloader.Form1.resources" />
-    <EmbeddedResource Include="obj\Debug\Netease_Music_Downloader.Properties.Resources.resources" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>


### PR DESCRIPTION
remove 2 lines of useless codes.
vs2019社区版会报错，删除无效引用